### PR TITLE
harden: sanitize child_process call in reset.js

### DIFF
--- a/bin/reset.js
+++ b/bin/reset.js
@@ -25,15 +25,12 @@ const matrix = require(matrixFile);
  * @param {import("./clone").MatrixItem} item
  */
 function syncAndResetRepo(item) {
-  const cmd = [
-    `cd repos/${item.path}`,
-    `git reset --hard`,
-    `git checkout ${item.ref}`,
-    `git pull`,
-  ].join(" && ");
+  const cwd = `repos/${item.path}`;
 
-  console.log(`Running ${cmd}`);
-  cp.execSync(cmd, { stdio: "inherit" });
+  console.log(`Resetting ${cwd} to ${item.ref}`);
+  cp.execFileSync("git", ["reset", "--hard"], { cwd, stdio: "inherit" });
+  cp.execFileSync("git", ["checkout", item.ref], { cwd, stdio: "inherit" });
+  cp.execFileSync("git", ["pull"], { cwd, stdio: "inherit" });
 }
 
 function reset() {


### PR DESCRIPTION
## Summary
Harden input handling in `bin/reset.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `bin/reset.js:36` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `item`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `bin/reset.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=javascript.lang.security.detect-child-process.detect-child-process scanner=semgrep -->
